### PR TITLE
added `colors` and `no-dither` arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Create a GIF from images or video:
 | `--start-time`   | float  | -       | Start time in seconds (video only)                           |
 | `--end-time`     | float  | -       | End time in seconds (video only)                             |
 | `--skip-frames`  | int    | 1       | Only use every Nth frame (video only)                        |
+| `--colors`       | int    | 256     | Maximum number of colors in the GIF palette (256 = full 8‑bit) |
+| `--no-dither`    | flag   | False   | Disable dithering; may create sharper edges in solid areas but can cause banding |
 
 #### Understanding `--skip-frames` and frame rate
 
@@ -102,6 +104,10 @@ From a list of explicit image files:
 From a video file (requires the `opencv` extra):
 
     poetry run python -m transimage gif video.mp4 -o clip.gif --fps 15 --start-time 2.5 --end-time 5 --size 320 240
+
+Reduce palette to 64 colors and turn off dithering for a crisp, retro look
+
+    poetry run python -m transimage gif ./frames -o movie.gif --fps 12 --colors 64 --no-dither
 
 ## Programmatic Usage
 
@@ -177,6 +183,9 @@ Please submit issues regarding any oversight you see. Pull requests for improvem
 5. Rise and repeat until finished.
 
 ## Changelog
+
+### 2.1.0 (24-06-2026)
+- Added `--colors` and `--no-dither` arguments to give the user more control over a GIF's output file size.
 
 ### 2.0.1 (20-06-2026)
 - Clarified README

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "transimage"
-version = "2.0.1"
+version = "2.1.0"
 description = "CLI tool for converting images between different formats and creating GIFs from image sequences, directories, or video files. Supports JPG, PNG, BMP, and WebP."
 authors = ["Daethyra <109057945+Daethyra@users.noreply.github.com>"]
 license = "MIT"

--- a/src/transimage/__main__.py
+++ b/src/transimage/__main__.py
@@ -67,7 +67,7 @@ def main() -> None:
         help="Input: directory, video file, or multiple image paths (list them after the command)",
     )
     gif_parser.add_argument("-o", "--output", required=True, help="Output GIF file path")
-    gif_parser.add_argument("--fps", type=float, default=24, help="Frames per second (default: 10)")
+    gif_parser.add_argument("--fps", type=float, default=24, help="Frames per second (default: 24)")
     gif_parser.add_argument(
         "--size", nargs=2, type=int, metavar=("WIDTH", "HEIGHT"),
         help="Resize frames to fit inside WIDTHxHEIGHT (aspect ratio kept)"
@@ -80,6 +80,8 @@ def main() -> None:
     gif_parser.add_argument("--start-time", type=float, default=None, help="Start time in seconds (video only)")
     gif_parser.add_argument("--end-time", type=float, default=None, help="End time in seconds (video only)")
     gif_parser.add_argument("--skip-frames", type=int, default=1, help="Take every Nth frame (video only)")
+    gif_parser.add_argument("--colors", type=int, default=256, help="Maximum number of colors in the GIF palette (default: 256)")
+    gif_parser.add_argument("--no-dither", action="store_true", default=False, help="Disable dithering to possibly increase compression at the cost of banding (default: dithering enabled)")
 
     # parse_known_args allows extra positional arguments (image files) to be collected
     args, unknown = parser.parse_known_args()
@@ -111,6 +113,8 @@ def main() -> None:
                 start_time=args.start_time,
                 end_time=args.end_time,
                 skip_frames=args.skip_frames,
+                colors=args.colors,
+                dither=not args.no_dither,
             )
             print("GIF created successfully.")
         except Exception as e:

--- a/src/transimage/gif_creator.py
+++ b/src/transimage/gif_creator.py
@@ -3,7 +3,6 @@ Module for creating GIFs from images, image directories, or video files.
 """
 
 import os
-from pathlib import Path
 from typing import List, Optional, Union, Tuple
 
 from PIL import Image
@@ -25,7 +24,13 @@ class GIFCreator:
         skip_frames: int = 1,                            # for video: take every Nth frame
         start_time: Optional[float] = None,              # seconds, video only
         end_time: Optional[float] = None,                # seconds, video only
+        colors: int = 256,                               # control maximum bitmap depth
+        dither: bool = True,                             # whether to dither. kinda sounds like a dance move
     ):
+        if not 2 <= colors <= 256:
+            raise ValueError(
+                f"colors must be between 2 and 256, got {colors}"
+            )
         self.sources = sources
         self.output_path = output_path
         self.fps = fps
@@ -37,6 +42,8 @@ class GIFCreator:
         self.skip_frames = skip_frames
         self.start_time = start_time
         self.end_time = end_time
+        self.colors = colors
+        self.dither = dither
 
     def _load_images_from_video(self, video_path: str) -> List[Image.Image]:
         """Extract frames from a video file using OpenCV."""
@@ -102,6 +109,23 @@ class GIFCreator:
                 img = img.convert("RGB")
             processed.append(img)
         return processed
+    
+    def _quantize_frames(self, frames: List[Image.Image]) -> List[Image.Image]:
+        """Reduce each frame to the selected palette using the configured dither setting."""
+        if self.colors >= 256:
+            return frames
+
+        quantized = []
+        dither_method = Image.Dither.FLOYDSTEINBERG if self.dither else Image.Dither.NONE
+        for img in frames:
+            # quantize() returns a new image, converts to 'P' mode with the given palette
+            q = img.quantize(
+                colors=self.colors,
+                method=Image.MEDIANCUT,      # median cut is fast and effective
+                dither=dither_method,
+            )
+            quantized.append(q)
+        return quantized
 
     def create(self) -> None:
         """Generate the GIF and save it."""
@@ -134,6 +158,9 @@ class GIFCreator:
 
         # 2. Process all frames (resize, crop, convert to RGB)
         frames = self._process_frames(images)
+        
+        # Quantize frames if color limit is set
+        frames = self._quantize_frames(frames)
 
         # 3. Save as GIF
         frames[0].save(
@@ -157,6 +184,8 @@ def create_gif(
     start_time: Optional[float] = None,
     end_time: Optional[float] = None,
     skip_frames: int = 1,
+    colors: int = 256,
+    dither: bool = True,
 ) -> None:
     """
     Convenience function to create a GIF with default parameters.
@@ -171,6 +200,8 @@ def create_gif(
         start_time: Start time in seconds (video only).
         end_time: End time in seconds (video only).
         skip_frames: Only use every Nth frame (video only).
+        colors: Maximum number of colors in the GIF palette (2‑256, default 256).
+        dither: Whether to apply dithering (True for Floyd‑Steinberg(default), False to disable).
     """
     creator = GIFCreator(
         sources=input,
@@ -182,5 +213,7 @@ def create_gif(
         start_time=start_time,
         end_time=end_time,
         skip_frames=skip_frames,
+        colors=colors,
+        dither=dither,
     )
     creator.create()


### PR DESCRIPTION
- Resolves #37 and #38
- added `colors` and `dither` parameters to `GIFCreator` and `create_gif`
- validate colors range (2-256)
- created CLI arguments in `__main__.py`
- changed dither argument in `save()` to use `Image.Dither enum` instead of bool
- ensured frame pre-quantization with `_quantize_frames` method to override Pillow's `optimize` functionality
- kept `optimize=True` *after* quantization to reduce output file size
- updated README